### PR TITLE
upgrade To .net6 + c#10 + rollforward latestMajor

### DIFF
--- a/YAM2E/YAM2E.csproj
+++ b/YAM2E/YAM2E.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades to .net6 (as .net core 5 is EOL in may) + c#10 + rollforward latestMajor (so that if .net7 comes out, people dont have to keep the .net6 sdk.)